### PR TITLE
Add support for Scoped distribution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,12 +93,15 @@ help: ## Display this help.
 
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 # CRD_OPTIONS ?= "crd:trivialVersions=true" # "crd:trivialVersions=true,preserveUnknownFields=false"
-CRD_OPTIONS ?= crd
+# crd:allowDangerousTypes=true is used to enable float64.
+# They are considered danger as support for them varies across languages. However, since they are
+# intended for use within the controllers, they are safe to use.
+CRD_OPTIONS ?= crd:allowDangerousTypes=true
 
 ##@ Development
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
-	$(CONTROLLER_GEN) $(CRD_OPTIONS) paths="./..."  output:crd:artifacts:config=${CRD_DIR}
+	$(CONTROLLER_GEN) $(CRD_OPTIONS) paths="./..." output:crd:artifacts:config=${CRD_DIR}
 	# $(CONTROLLER_GEN) webhook paths="./..."  output:webhook:artifacts:config=${WEBHOOK_DIR}
 	$(CONTROLLER_GEN) rbac:roleName=frisbee paths="./..."  output:rbac:artifacts:config=${RBAC_DIR}
 

--- a/api/v1alpha1/admission_cluster.go
+++ b/api/v1alpha1/admission_cluster.go
@@ -45,6 +45,9 @@ func (in *Cluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
 func (in *Cluster) Default() {
 	clusterlog.Info("default", "name", in.Name)
 
+	/*
+		Make the inputs consistent with MaxInstances.
+	*/
 	if err := in.Spec.GenerateObjectFromTemplate.Prepare(true); err != nil {
 		clusterlog.Error(err, "template error")
 	}

--- a/api/v1alpha1/admission_common.go
+++ b/api/v1alpha1/admission_common.go
@@ -81,17 +81,20 @@ func ValidateScheduler(instances int, sch *SchedulerSpec) error {
 }
 
 func ValidateDistribution(dist *DistributionSpec) error {
-	switch dist.Distribution {
-	case "constant":
+	switch dist.Name {
+	case DistributionConstant:
 		return nil
 
-	case "uniform":
+	case DistributionUniform:
 		return nil
 
-	case "zipfian":
+	case DistributionZipfian:
 		return nil
 
-	case "histogram":
+	case DistributionHistogram:
+		return nil
+
+	case DistributionDefault:
 		return nil
 	}
 	/* TODO: continue with the other distributions */

--- a/api/v1alpha1/crd_cluster.go
+++ b/api/v1alpha1/crd_cluster.go
@@ -52,18 +52,27 @@ type PlacementSpec struct {
 type ClusterSpec struct {
 	GenerateObjectFromTemplate `json:",inline"`
 
-	// Resources defines how a set of resources will be distributed among the cluster's services.
-	// +optional
-	Resources *ResourceDistributionSpec `json:"resources,omitempty"`
+	/*
+		Preparation of Grouped Environment
+	*/
 
 	// TestData defines a volume that will be mounted across the Scenario's Services.
 	// +optional
 	TestData *TestdataVolume `json:"testData,omitempty"`
 
-	// Tolerate specifies the conditions under which the cluster will fail. If undefined, the cluster fails
-	// immediately when a service has failed.
+	// DefaultDistributionSpec pre-calculates a scoped distribution that can be accessed by other entities
+	// using  "distribution.name : default". This default distribution allows us to describe complex relations
+	// across features managed by different entities  (e.g, place the largest dataset on the largest node).
 	// +optional
-	Tolerate *TolerateSpec `json:"tolerate,omitempty"`
+	DefaultDistributionSpec *DistributionSpec `json:"defaultDistribution,omitempty"`
+
+	/*
+		Instance Creation Functions
+	*/
+
+	// Resources defines how a set of resources will be distributed among the cluster's services.
+	// +optional
+	Resources *ResourceDistributionSpec `json:"resources,omitempty"`
 
 	// Schedule defines the interval between the creation of services in the group.
 	// +optional
@@ -73,15 +82,28 @@ type ClusterSpec struct {
 	// +optional
 	Placement *PlacementSpec `json:"placement,omitempty"`
 
+	/*
+		Error Management
+	*/
+
 	// Suspend flag tells the controller to suspend subsequent executions, it does not apply to already started
 	// executions.  Defaults to false.
 	// +optional
 	Suspend *bool `json:"suspend,omitempty"`
+
+	// Tolerate specifies the conditions under which the cluster will fail. If undefined, the cluster fails
+	// immediately when a service has failed.
+	// +optional
+	Tolerate *TolerateSpec `json:"tolerate,omitempty"`
 }
 
 // ClusterStatus defines the observed state of Cluster.
 type ClusterStatus struct {
 	Lifecycle `json:",inline"`
+
+	// DefaultDistribution keeps the evaluated expression of GenerateObjectFromTemplate.DefaultDistributionSpec.
+	// +optional
+	DefaultDistribution []float64 `json:"defaultDistribution,omitempty"`
 
 	// QueuedJobs is a list of services scheduled for creation by the cluster.
 	// +optional

--- a/api/v1alpha1/crd_scenario.go
+++ b/api/v1alpha1/crd_scenario.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/json"
 )
@@ -66,52 +65,6 @@ func (in *Scenario) Table() (header []string, data [][]string) {
 	})
 
 	return header, data
-}
-
-/*
-FindTimeline parses the scenario to find timeline that make sense (formatted into time.UnixMilli).
-For the starting time we adhere to these rules:
- 1. If possible, we use the time that the first job was scheduled.
- 2. Otherwise, we use the Creation time.
-
-For the ending time we adhere to these rules:
- 1. If the scenario is successful, we return the ConditionAllJobsAreCompleted time.
- 2. If the scenario has failed, we return the Failure time.
- 3. Otherwise, we report time.Now().
-*/
-func (in *Scenario) FindTimeline() (from int64, to int64) {
-	initialized := meta.FindStatusCondition(in.Status.Conditions, ConditionCRInitialized.String())
-	if initialized != nil {
-		from = initialized.LastTransitionTime.Time.UnixMilli()
-	} else {
-		from = in.GetCreationTimestamp().Time.UnixMilli()
-	}
-
-	to = time.Now().UnixMilli()
-
-	switch in.Status.Phase {
-	case PhaseSuccess:
-		success := meta.FindStatusCondition(in.Status.Conditions, ConditionAllJobsAreCompleted.String())
-		to = success.LastTransitionTime.Time.UnixMilli()
-
-	case PhaseFailed:
-		// Failure may come from various reasons. Unfortunately we have to go through all of them.
-		unexpected := meta.FindStatusCondition(in.Status.Conditions, ConditionJobUnexpectedTermination.String())
-		if unexpected != nil {
-			to = unexpected.LastTransitionTime.Time.UnixMilli()
-
-			break
-		}
-
-		assert := meta.FindStatusCondition(in.Status.Conditions, ConditionAssertionError.String())
-		if assert != nil {
-			to = assert.LastTransitionTime.Time.UnixMilli()
-
-			break
-		}
-	}
-
-	return from, to
 }
 
 type ActionType string

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -493,20 +493,20 @@ func (in *ClusterList) DeepCopyObject() runtime.Object {
 func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 	*out = *in
 	in.GenerateObjectFromTemplate.DeepCopyInto(&out.GenerateObjectFromTemplate)
-	if in.Resources != nil {
-		in, out := &in.Resources, &out.Resources
-		*out = new(ResourceDistributionSpec)
-		(*in).DeepCopyInto(*out)
-	}
 	if in.TestData != nil {
 		in, out := &in.TestData, &out.TestData
 		*out = new(TestdataVolume)
 		**out = **in
 	}
-	if in.Tolerate != nil {
-		in, out := &in.Tolerate, &out.Tolerate
-		*out = new(TolerateSpec)
-		**out = **in
+	if in.DefaultDistributionSpec != nil {
+		in, out := &in.DefaultDistributionSpec, &out.DefaultDistributionSpec
+		*out = new(DistributionSpec)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.Resources != nil {
+		in, out := &in.Resources, &out.Resources
+		*out = new(ResourceDistributionSpec)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Schedule != nil {
 		in, out := &in.Schedule, &out.Schedule
@@ -521,6 +521,11 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 	if in.Suspend != nil {
 		in, out := &in.Suspend, &out.Suspend
 		*out = new(bool)
+		**out = **in
+	}
+	if in.Tolerate != nil {
+		in, out := &in.Tolerate, &out.Tolerate
+		*out = new(TolerateSpec)
 		**out = **in
 	}
 }
@@ -539,6 +544,11 @@ func (in *ClusterSpec) DeepCopy() *ClusterSpec {
 func (in *ClusterStatus) DeepCopyInto(out *ClusterStatus) {
 	*out = *in
 	in.Lifecycle.DeepCopyInto(&out.Lifecycle)
+	if in.DefaultDistribution != nil {
+		in, out := &in.DefaultDistribution, &out.DefaultDistribution
+		*out = make([]float64, len(*in))
+		copy(*out, *in)
+	}
 	if in.QueuedJobs != nil {
 		in, out := &in.QueuedJobs, &out.QueuedJobs
 		*out = make([]ServiceSpec, len(*in))

--- a/charts/databases/cockroachdb/examples/1.baseline-single.yml
+++ b/charts/databases/cockroachdb/examples/1.baseline-single.yml
@@ -21,8 +21,9 @@ spec:
         inputs:
           - { server: master, workload: workloada, recordcount: "1000000", threads: "400", delay: "15" }
         resources:
+          distribution:
+            name: constant
           total: { cpu: "2", memory: "100Mi" }
-          distribution: constant
 
     # Step 3. Run YCSB workload A
     - action: Service

--- a/charts/federated-learning/fedbed/examples/0.baseline.yml
+++ b/charts/federated-learning/fedbed/examples/0.baseline.yml
@@ -35,6 +35,6 @@ spec:
     # Teardown
     - action: Delete
       name: teardown
-      depends: { running: [ server ], success: [ clients ] }
+      depends: { success: [ clients, server ] }
       delete:
-        jobs: [ server ]
+        jobs: []

--- a/charts/federated-learning/fedbed/examples/0.baseline.yml
+++ b/charts/federated-learning/fedbed/examples/0.baseline.yml
@@ -27,10 +27,17 @@ spec:
       depends: { running: [ server ], success: [ cifar10-download ]  }
       cluster:
         templateRef: fedbed.client
+        defaultDistribution:
+          name: constant
         inputs:
           - { fl_server: server, dataset: fl.datasets.cifar10, node_id: 0, total_nodes: 3 }
           - { fl_server: server, dataset: fl.datasets.cifar10, node_id: 1, total_nodes: 3 }
           - { fl_server: server, dataset: fl.datasets.cifar10, node_id: 2, total_nodes: 3 }
+        resources:
+          distribution:
+            name: default
+          total: {mem: 500Mi}
+
 
     # Teardown
     - action: Delete

--- a/charts/federated-learning/fedbed/templates/services.yaml
+++ b/charts/federated-learning/fedbed/templates/services.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   inputs:
     parameters:
-      min_eval_clients: 2
       min_fit_clients: 2
       min_available_clients: 2
   service:
@@ -23,7 +22,7 @@ spec:
           - name:  FL_FRACTION_EVAL
             value: "0.1"
           - name:  FL_MIN_EVAL_CLIENTS
-            value: {{"{{.inputs.parameters.min_eval_clients}}" | quote}}
+            value: {{"{{.inputs.parameters.min_available_clients}}" | quote}}
           - name:  FL_MIN_FIT_CLIENTS
             value: {{"{{.inputs.parameters.min_fit_clients}}" | quote }}
           - name:  FL_MIN_AVAILABLE_CLIENTS
@@ -79,13 +78,12 @@ spec:
         env:
           - name:  FL_SERVER
             value: {{"{{.inputs.parameters.fl_server}}" | quote }}
-
           - name:  FL_BACKEND
-            value: pytorch
+            value:  {{"{{.inputs.parameters.backend}}" | quote }}
           - name:  FL_NUM_OF_THREADS
             value: "1"
 
-          # Are these values really neeeded here?
+          # Are these values really needed here?
           - name:  FL_NODES
             value: {{"{{.inputs.parameters.total_nodes}}" | quote}}
           - name:  FL_NODE_ID
@@ -97,21 +95,6 @@ spec:
           - name:  FL_DATASET_RANDOM
             value: "false"
 
-          - name: SKATA
-            value: {{"{{ (.inputs.parameters.dataset) }}" | quote}}
-
-          - name: SKATA1
-            value: {{"{{ (base .inputs.parameters.dataset) }}" | quote}}
-
-          - name: SKATA2
-            value: {{"{{ (osBase .inputs.parameters.dataset) }}" | quote}}
-
-          - name: SKATA3
-            value: {{"{{ (.inputs.parameters.dataset | base) }}" | quote}}
-
-          - name: SKATA4
-            value: {{"{{ (.inputs.parameters.dataset | osBase) }}" | quote}}
-
         command: ["/bin/sh", "-c"]
         args:
           - | # Script
@@ -120,5 +103,4 @@ spec:
             # do it like that until I find a better way to go from fl.dataset.cifar10 to cifar10.
             FL_DATASET=$(basename {{"{{.inputs.parameters.dataset}}"}})
 
-            tail -f /dev/null
-
+            python client.py

--- a/charts/federated-learning/flower/README.md
+++ b/charts/federated-learning/flower/README.md
@@ -1,4 +1,4 @@
-# FedBed
+# Flower
 
 
 

--- a/charts/platform/crds/frisbee.dev_calls.yaml
+++ b/charts/platform/crds/frisbee.dev_calls.yaml
@@ -96,63 +96,71 @@ spec:
                     description: Timeline creates a timeline that honors the underlying
                       distribution.
                     properties:
-                      constant:
-                        description: DistParamsConstant are parameters for the constant
-                          distribution.
-                        properties:
-                          value:
-                            format: int64
-                            type: integer
-                        required:
-                        - value
-                        type: object
                       distribution:
-                        enum:
-                        - constant
-                        - uniform
-                        - zipfian
-                        - histogram
-                        type: string
-                      histogram:
-                        description: DistParamsHistogram are parameters for the constant
-                          distribution.
+                        description: DistributionSpec defines how the TotalDuration
+                          will be divided into time-based events.
                         properties:
-                          blockSize:
-                            format: int64
-                            type: integer
-                          buckets:
-                            items:
-                              format: int64
-                              type: integer
-                            type: array
+                          constant:
+                            description: DistParamsConstant are parameters for the
+                              constant distribution.
+                            properties:
+                              value:
+                                format: int64
+                                type: integer
+                            required:
+                            - value
+                            type: object
+                          histogram:
+                            description: DistParamsHistogram are parameters for the
+                              constant distribution.
+                            properties:
+                              blockSize:
+                                format: int64
+                                type: integer
+                              buckets:
+                                items:
+                                  format: int64
+                                  type: integer
+                                type: array
+                            required:
+                            - blockSize
+                            - buckets
+                            type: object
+                          name:
+                            enum:
+                            - constant
+                            - uniform
+                            - zipfian
+                            - histogram
+                            - default
+                            type: string
+                          uniform:
+                            description: DistParamsUniform are parameters for the
+                              constant distribution.
+                            properties:
+                              max:
+                                format: int64
+                                type: integer
+                            required:
+                            - max
+                            type: object
+                          zipfian:
+                            description: DistParamsZipfian are parameters for the
+                              constant distribution.
+                            properties:
+                              max:
+                                format: int64
+                                type: integer
+                            required:
+                            - max
+                            type: object
                         required:
-                        - blockSize
-                        - buckets
+                        - name
                         type: object
                       total:
                         description: TotalDuration defines the total duration within
                           which events will happen.
                         type: string
-                      uniform:
-                        description: DistParamsUniform are parameters for the constant
-                          distribution.
-                        properties:
-                          max:
-                            format: int64
-                            type: integer
-                        required:
-                        - max
-                        type: object
-                      zipfian:
-                        description: DistParamsZipfian are parameters for the constant
-                          distribution.
-                        properties:
-                          max:
-                            format: int64
-                            type: integer
-                        required:
-                        - max
-                        type: object
                     required:
                     - distribution
                     - total

--- a/charts/platform/crds/frisbee.dev_cascades.yaml
+++ b/charts/platform/crds/frisbee.dev_cascades.yaml
@@ -89,63 +89,71 @@ spec:
                     description: Timeline creates a timeline that honors the underlying
                       distribution.
                     properties:
-                      constant:
-                        description: DistParamsConstant are parameters for the constant
-                          distribution.
-                        properties:
-                          value:
-                            format: int64
-                            type: integer
-                        required:
-                        - value
-                        type: object
                       distribution:
-                        enum:
-                        - constant
-                        - uniform
-                        - zipfian
-                        - histogram
-                        type: string
-                      histogram:
-                        description: DistParamsHistogram are parameters for the constant
-                          distribution.
+                        description: DistributionSpec defines how the TotalDuration
+                          will be divided into time-based events.
                         properties:
-                          blockSize:
-                            format: int64
-                            type: integer
-                          buckets:
-                            items:
-                              format: int64
-                              type: integer
-                            type: array
+                          constant:
+                            description: DistParamsConstant are parameters for the
+                              constant distribution.
+                            properties:
+                              value:
+                                format: int64
+                                type: integer
+                            required:
+                            - value
+                            type: object
+                          histogram:
+                            description: DistParamsHistogram are parameters for the
+                              constant distribution.
+                            properties:
+                              blockSize:
+                                format: int64
+                                type: integer
+                              buckets:
+                                items:
+                                  format: int64
+                                  type: integer
+                                type: array
+                            required:
+                            - blockSize
+                            - buckets
+                            type: object
+                          name:
+                            enum:
+                            - constant
+                            - uniform
+                            - zipfian
+                            - histogram
+                            - default
+                            type: string
+                          uniform:
+                            description: DistParamsUniform are parameters for the
+                              constant distribution.
+                            properties:
+                              max:
+                                format: int64
+                                type: integer
+                            required:
+                            - max
+                            type: object
+                          zipfian:
+                            description: DistParamsZipfian are parameters for the
+                              constant distribution.
+                            properties:
+                              max:
+                                format: int64
+                                type: integer
+                            required:
+                            - max
+                            type: object
                         required:
-                        - blockSize
-                        - buckets
+                        - name
                         type: object
                       total:
                         description: TotalDuration defines the total duration within
                           which events will happen.
                         type: string
-                      uniform:
-                        description: DistParamsUniform are parameters for the constant
-                          distribution.
-                        properties:
-                          max:
-                            format: int64
-                            type: integer
-                        required:
-                        - max
-                        type: object
-                      zipfian:
-                        description: DistParamsZipfian are parameters for the constant
-                          distribution.
-                        properties:
-                          max:
-                            format: int64
-                            type: integer
-                        required:
-                        - max
-                        type: object
                     required:
                     - distribution
                     - total

--- a/charts/platform/crds/frisbee.dev_clusters.yaml
+++ b/charts/platform/crds/frisbee.dev_clusters.yaml
@@ -35,6 +35,70 @@ spec:
           spec:
             description: ClusterSpec defines the desired state of Cluster.
             properties:
+              defaultDistribution:
+                description: 'DefaultDistributionSpec pre-calculates a scoped distribution
+                  that can be accessed by other entities using  "distribution.name
+                  : default". This default distribution allows us to describe complex
+                  relations across features managed by different entities  (e.g, place
+                  the largest dataset on the largest node).'
+                properties:
+                  constant:
+                    description: DistParamsConstant are parameters for the constant
+                      distribution.
+                    properties:
+                      value:
+                        format: int64
+                        type: integer
+                    required:
+                    - value
+                    type: object
+                  histogram:
+                    description: DistParamsHistogram are parameters for the constant
+                      distribution.
+                    properties:
+                      blockSize:
+                        format: int64
+                        type: integer
+                      buckets:
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                    required:
+                    - blockSize
+                    - buckets
+                    type: object
+                  name:
+                    enum:
+                    - constant
+                    - uniform
+                    - zipfian
+                    - histogram
+                    - default
+                    type: string
+                  uniform:
+                    description: DistParamsUniform are parameters for the constant
+                      distribution.
+                    properties:
+                      max:
+                        format: int64
+                        type: integer
+                    required:
+                    - max
+                    type: object
+                  zipfian:
+                    description: DistParamsZipfian are parameters for the constant
+                      distribution.
+                    properties:
+                      max:
+                        format: int64
+                        type: integer
+                    required:
+                    - max
+                    type: object
+                required:
+                - name
+                type: object
               inputs:
                 description: UserParameters is a map of parameters passed to the objects.
                   Event used in conjunction with instances, if the number of instances
@@ -78,38 +142,66 @@ spec:
                 description: Resources defines how a set of resources will be distributed
                   among the cluster's services.
                 properties:
-                  constant:
-                    description: DistParamsConstant are parameters for the constant
-                      distribution.
-                    properties:
-                      value:
-                        format: int64
-                        type: integer
-                    required:
-                    - value
-                    type: object
                   distribution:
-                    enum:
-                    - constant
-                    - uniform
-                    - zipfian
-                    - histogram
-                    type: string
-                  histogram:
-                    description: DistParamsHistogram are parameters for the constant
-                      distribution.
+                    description: DistributionSpec defines how the TotalResources will
+                      be assigned to resources.
                     properties:
-                      blockSize:
-                        format: int64
-                        type: integer
-                      buckets:
-                        items:
-                          format: int64
-                          type: integer
-                        type: array
+                      constant:
+                        description: DistParamsConstant are parameters for the constant
+                          distribution.
+                        properties:
+                          value:
+                            format: int64
+                            type: integer
+                        required:
+                        - value
+                        type: object
+                      histogram:
+                        description: DistParamsHistogram are parameters for the constant
+                          distribution.
+                        properties:
+                          blockSize:
+                            format: int64
+                            type: integer
+                          buckets:
+                            items:
+                              format: int64
+                              type: integer
+                            type: array
+                        required:
+                        - blockSize
+                        - buckets
+                        type: object
+                      name:
+                        enum:
+                        - constant
+                        - uniform
+                        - zipfian
+                        - histogram
+                        - default
+                        type: string
+                      uniform:
+                        description: DistParamsUniform are parameters for the constant
+                          distribution.
+                        properties:
+                          max:
+                            format: int64
+                            type: integer
+                        required:
+                        - max
+                        type: object
+                      zipfian:
+                        description: DistParamsZipfian are parameters for the constant
+                          distribution.
+                        properties:
+                          max:
+                            format: int64
+                            type: integer
+                        required:
+                        - max
+                        type: object
                     required:
-                    - blockSize
-                    - buckets
+                    - name
                     type: object
                   total:
                     additionalProperties:
@@ -120,26 +212,6 @@ spec:
                       x-kubernetes-int-or-string: true
                     description: TotalResources defines the total resources that will
                       be distributed among the cluster's services.
-                    type: object
-                  uniform:
-                    description: DistParamsUniform are parameters for the constant
-                      distribution.
-                    properties:
-                      max:
-                        format: int64
-                        type: integer
-                    required:
-                    - max
-                    type: object
-                  zipfian:
-                    description: DistParamsZipfian are parameters for the constant
-                      distribution.
-                    properties:
-                      max:
-                        format: int64
-                        type: integer
-                    required:
-                    - max
                     type: object
                 required:
                 - distribution
@@ -183,63 +255,71 @@ spec:
                     description: Timeline creates a timeline that honors the underlying
                       distribution.
                     properties:
-                      constant:
-                        description: DistParamsConstant are parameters for the constant
-                          distribution.
-                        properties:
-                          value:
-                            format: int64
-                            type: integer
-                        required:
-                        - value
-                        type: object
                       distribution:
-                        enum:
-                        - constant
-                        - uniform
-                        - zipfian
-                        - histogram
-                        type: string
-                      histogram:
-                        description: DistParamsHistogram are parameters for the constant
-                          distribution.
+                        description: DistributionSpec defines how the TotalDuration
+                          will be divided into time-based events.
                         properties:
-                          blockSize:
-                            format: int64
-                            type: integer
-                          buckets:
-                            items:
-                              format: int64
-                              type: integer
-                            type: array
+                          constant:
+                            description: DistParamsConstant are parameters for the
+                              constant distribution.
+                            properties:
+                              value:
+                                format: int64
+                                type: integer
+                            required:
+                            - value
+                            type: object
+                          histogram:
+                            description: DistParamsHistogram are parameters for the
+                              constant distribution.
+                            properties:
+                              blockSize:
+                                format: int64
+                                type: integer
+                              buckets:
+                                items:
+                                  format: int64
+                                  type: integer
+                                type: array
+                            required:
+                            - blockSize
+                            - buckets
+                            type: object
+                          name:
+                            enum:
+                            - constant
+                            - uniform
+                            - zipfian
+                            - histogram
+                            - default
+                            type: string
+                          uniform:
+                            description: DistParamsUniform are parameters for the
+                              constant distribution.
+                            properties:
+                              max:
+                                format: int64
+                                type: integer
+                            required:
+                            - max
+                            type: object
+                          zipfian:
+                            description: DistParamsZipfian are parameters for the
+                              constant distribution.
+                            properties:
+                              max:
+                                format: int64
+                                type: integer
+                            required:
+                            - max
+                            type: object
                         required:
-                        - blockSize
-                        - buckets
+                        - name
                         type: object
                       total:
                         description: TotalDuration defines the total duration within
                           which events will happen.
                         type: string
-                      uniform:
-                        description: DistParamsUniform are parameters for the constant
-                          distribution.
-                        properties:
-                          max:
-                            format: int64
-                            type: integer
-                        required:
-                        - max
-                        type: object
-                      zipfian:
-                        description: DistParamsZipfian are parameters for the constant
-                          distribution.
-                        properties:
-                          max:
-                            format: int64
-                            type: integer
-                        required:
-                        - max
-                        type: object
                     required:
                     - distribution
                     - total
@@ -387,6 +467,12 @@ spec:
                   - status
                   - type
                   type: object
+                type: array
+              defaultDistribution:
+                description: DefaultDistribution keeps the evaluated expression of
+                  GenerateObjectFromTemplate.DefaultDistributionSpec.
+                items:
+                  type: number
                 type: array
               lastScheduleTime:
                 description: LastScheduleTime provide information about  the last

--- a/charts/platform/crds/frisbee.dev_scenarios.yaml
+++ b/charts/platform/crds/frisbee.dev_scenarios.yaml
@@ -143,63 +143,71 @@ spec:
                               description: Timeline creates a timeline that honors
                                 the underlying distribution.
                               properties:
-                                constant:
-                                  description: DistParamsConstant are parameters for
-                                    the constant distribution.
-                                  properties:
-                                    value:
-                                      format: int64
-                                      type: integer
-                                  required:
-                                  - value
-                                  type: object
                                 distribution:
-                                  enum:
-                                  - constant
-                                  - uniform
-                                  - zipfian
-                                  - histogram
-                                  type: string
-                                histogram:
-                                  description: DistParamsHistogram are parameters
-                                    for the constant distribution.
+                                  description: DistributionSpec defines how the TotalDuration
+                                    will be divided into time-based events.
                                   properties:
-                                    blockSize:
-                                      format: int64
-                                      type: integer
-                                    buckets:
-                                      items:
-                                        format: int64
-                                        type: integer
-                                      type: array
+                                    constant:
+                                      description: DistParamsConstant are parameters
+                                        for the constant distribution.
+                                      properties:
+                                        value:
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - value
+                                      type: object
+                                    histogram:
+                                      description: DistParamsHistogram are parameters
+                                        for the constant distribution.
+                                      properties:
+                                        blockSize:
+                                          format: int64
+                                          type: integer
+                                        buckets:
+                                          items:
+                                            format: int64
+                                            type: integer
+                                          type: array
+                                      required:
+                                      - blockSize
+                                      - buckets
+                                      type: object
+                                    name:
+                                      enum:
+                                      - constant
+                                      - uniform
+                                      - zipfian
+                                      - histogram
+                                      - default
+                                      type: string
+                                    uniform:
+                                      description: DistParamsUniform are parameters
+                                        for the constant distribution.
+                                      properties:
+                                        max:
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - max
+                                      type: object
+                                    zipfian:
+                                      description: DistParamsZipfian are parameters
+                                        for the constant distribution.
+                                      properties:
+                                        max:
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - max
+                                      type: object
                                   required:
-                                  - blockSize
-                                  - buckets
+                                  - name
                                   type: object
                                 total:
                                   description: TotalDuration defines the total duration
                                     within which events will happen.
                                   type: string
-                                uniform:
-                                  description: DistParamsUniform are parameters for
-                                    the constant distribution.
-                                  properties:
-                                    max:
-                                      format: int64
-                                      type: integer
-                                  required:
-                                  - max
-                                  type: object
-                                zipfian:
-                                  description: DistParamsZipfian are parameters for
-                                    the constant distribution.
-                                  properties:
-                                    max:
-                                      format: int64
-                                      type: integer
-                                  required:
-                                  - max
-                                  type: object
                               required:
                               - distribution
                               - total
@@ -313,63 +321,71 @@ spec:
                               description: Timeline creates a timeline that honors
                                 the underlying distribution.
                               properties:
-                                constant:
-                                  description: DistParamsConstant are parameters for
-                                    the constant distribution.
-                                  properties:
-                                    value:
-                                      format: int64
-                                      type: integer
-                                  required:
-                                  - value
-                                  type: object
                                 distribution:
-                                  enum:
-                                  - constant
-                                  - uniform
-                                  - zipfian
-                                  - histogram
-                                  type: string
-                                histogram:
-                                  description: DistParamsHistogram are parameters
-                                    for the constant distribution.
+                                  description: DistributionSpec defines how the TotalDuration
+                                    will be divided into time-based events.
                                   properties:
-                                    blockSize:
-                                      format: int64
-                                      type: integer
-                                    buckets:
-                                      items:
-                                        format: int64
-                                        type: integer
-                                      type: array
+                                    constant:
+                                      description: DistParamsConstant are parameters
+                                        for the constant distribution.
+                                      properties:
+                                        value:
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - value
+                                      type: object
+                                    histogram:
+                                      description: DistParamsHistogram are parameters
+                                        for the constant distribution.
+                                      properties:
+                                        blockSize:
+                                          format: int64
+                                          type: integer
+                                        buckets:
+                                          items:
+                                            format: int64
+                                            type: integer
+                                          type: array
+                                      required:
+                                      - blockSize
+                                      - buckets
+                                      type: object
+                                    name:
+                                      enum:
+                                      - constant
+                                      - uniform
+                                      - zipfian
+                                      - histogram
+                                      - default
+                                      type: string
+                                    uniform:
+                                      description: DistParamsUniform are parameters
+                                        for the constant distribution.
+                                      properties:
+                                        max:
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - max
+                                      type: object
+                                    zipfian:
+                                      description: DistParamsZipfian are parameters
+                                        for the constant distribution.
+                                      properties:
+                                        max:
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - max
+                                      type: object
                                   required:
-                                  - blockSize
-                                  - buckets
+                                  - name
                                   type: object
                                 total:
                                   description: TotalDuration defines the total duration
                                     within which events will happen.
                                   type: string
-                                uniform:
-                                  description: DistParamsUniform are parameters for
-                                    the constant distribution.
-                                  properties:
-                                    max:
-                                      format: int64
-                                      type: integer
-                                  required:
-                                  - max
-                                  type: object
-                                zipfian:
-                                  description: DistParamsZipfian are parameters for
-                                    the constant distribution.
-                                  properties:
-                                    max:
-                                      format: int64
-                                      type: integer
-                                  required:
-                                  - max
-                                  type: object
                               required:
                               - distribution
                               - total
@@ -458,6 +474,71 @@ spec:
                     cluster:
                       description: ClusterSpec defines the desired state of Cluster.
                       properties:
+                        defaultDistribution:
+                          description: 'DefaultDistributionSpec pre-calculates a scoped
+                            distribution that can be accessed by other entities using  "distribution.name
+                            : default". This default distribution allows us to describe
+                            complex relations across features managed by different
+                            entities  (e.g, place the largest dataset on the largest
+                            node).'
+                          properties:
+                            constant:
+                              description: DistParamsConstant are parameters for the
+                                constant distribution.
+                              properties:
+                                value:
+                                  format: int64
+                                  type: integer
+                              required:
+                              - value
+                              type: object
+                            histogram:
+                              description: DistParamsHistogram are parameters for
+                                the constant distribution.
+                              properties:
+                                blockSize:
+                                  format: int64
+                                  type: integer
+                                buckets:
+                                  items:
+                                    format: int64
+                                    type: integer
+                                  type: array
+                              required:
+                              - blockSize
+                              - buckets
+                              type: object
+                            name:
+                              enum:
+                              - constant
+                              - uniform
+                              - zipfian
+                              - histogram
+                              - default
+                              type: string
+                            uniform:
+                              description: DistParamsUniform are parameters for the
+                                constant distribution.
+                              properties:
+                                max:
+                                  format: int64
+                                  type: integer
+                              required:
+                              - max
+                              type: object
+                            zipfian:
+                              description: DistParamsZipfian are parameters for the
+                                constant distribution.
+                              properties:
+                                max:
+                                  format: int64
+                                  type: integer
+                              required:
+                              - max
+                              type: object
+                          required:
+                          - name
+                          type: object
                         inputs:
                           description: UserParameters is a map of parameters passed
                             to the objects. Event used in conjunction with instances,
@@ -502,38 +583,66 @@ spec:
                           description: Resources defines how a set of resources will
                             be distributed among the cluster's services.
                           properties:
-                            constant:
-                              description: DistParamsConstant are parameters for the
-                                constant distribution.
-                              properties:
-                                value:
-                                  format: int64
-                                  type: integer
-                              required:
-                              - value
-                              type: object
                             distribution:
-                              enum:
-                              - constant
-                              - uniform
-                              - zipfian
-                              - histogram
-                              type: string
-                            histogram:
-                              description: DistParamsHistogram are parameters for
-                                the constant distribution.
+                              description: DistributionSpec defines how the TotalResources
+                                will be assigned to resources.
                               properties:
-                                blockSize:
-                                  format: int64
-                                  type: integer
-                                buckets:
-                                  items:
-                                    format: int64
-                                    type: integer
-                                  type: array
+                                constant:
+                                  description: DistParamsConstant are parameters for
+                                    the constant distribution.
+                                  properties:
+                                    value:
+                                      format: int64
+                                      type: integer
+                                  required:
+                                  - value
+                                  type: object
+                                histogram:
+                                  description: DistParamsHistogram are parameters
+                                    for the constant distribution.
+                                  properties:
+                                    blockSize:
+                                      format: int64
+                                      type: integer
+                                    buckets:
+                                      items:
+                                        format: int64
+                                        type: integer
+                                      type: array
+                                  required:
+                                  - blockSize
+                                  - buckets
+                                  type: object
+                                name:
+                                  enum:
+                                  - constant
+                                  - uniform
+                                  - zipfian
+                                  - histogram
+                                  - default
+                                  type: string
+                                uniform:
+                                  description: DistParamsUniform are parameters for
+                                    the constant distribution.
+                                  properties:
+                                    max:
+                                      format: int64
+                                      type: integer
+                                  required:
+                                  - max
+                                  type: object
+                                zipfian:
+                                  description: DistParamsZipfian are parameters for
+                                    the constant distribution.
+                                  properties:
+                                    max:
+                                      format: int64
+                                      type: integer
+                                  required:
+                                  - max
+                                  type: object
                               required:
-                              - blockSize
-                              - buckets
+                              - name
                               type: object
                             total:
                               additionalProperties:
@@ -544,26 +653,6 @@ spec:
                                 x-kubernetes-int-or-string: true
                               description: TotalResources defines the total resources
                                 that will be distributed among the cluster's services.
-                              type: object
-                            uniform:
-                              description: DistParamsUniform are parameters for the
-                                constant distribution.
-                              properties:
-                                max:
-                                  format: int64
-                                  type: integer
-                              required:
-                              - max
-                              type: object
-                            zipfian:
-                              description: DistParamsZipfian are parameters for the
-                                constant distribution.
-                              properties:
-                                max:
-                                  format: int64
-                                  type: integer
-                              required:
-                              - max
                               type: object
                           required:
                           - distribution
@@ -611,63 +700,71 @@ spec:
                               description: Timeline creates a timeline that honors
                                 the underlying distribution.
                               properties:
-                                constant:
-                                  description: DistParamsConstant are parameters for
-                                    the constant distribution.
-                                  properties:
-                                    value:
-                                      format: int64
-                                      type: integer
-                                  required:
-                                  - value
-                                  type: object
                                 distribution:
-                                  enum:
-                                  - constant
-                                  - uniform
-                                  - zipfian
-                                  - histogram
-                                  type: string
-                                histogram:
-                                  description: DistParamsHistogram are parameters
-                                    for the constant distribution.
+                                  description: DistributionSpec defines how the TotalDuration
+                                    will be divided into time-based events.
                                   properties:
-                                    blockSize:
-                                      format: int64
-                                      type: integer
-                                    buckets:
-                                      items:
-                                        format: int64
-                                        type: integer
-                                      type: array
+                                    constant:
+                                      description: DistParamsConstant are parameters
+                                        for the constant distribution.
+                                      properties:
+                                        value:
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - value
+                                      type: object
+                                    histogram:
+                                      description: DistParamsHistogram are parameters
+                                        for the constant distribution.
+                                      properties:
+                                        blockSize:
+                                          format: int64
+                                          type: integer
+                                        buckets:
+                                          items:
+                                            format: int64
+                                            type: integer
+                                          type: array
+                                      required:
+                                      - blockSize
+                                      - buckets
+                                      type: object
+                                    name:
+                                      enum:
+                                      - constant
+                                      - uniform
+                                      - zipfian
+                                      - histogram
+                                      - default
+                                      type: string
+                                    uniform:
+                                      description: DistParamsUniform are parameters
+                                        for the constant distribution.
+                                      properties:
+                                        max:
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - max
+                                      type: object
+                                    zipfian:
+                                      description: DistParamsZipfian are parameters
+                                        for the constant distribution.
+                                      properties:
+                                        max:
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - max
+                                      type: object
                                   required:
-                                  - blockSize
-                                  - buckets
+                                  - name
                                   type: object
                                 total:
                                   description: TotalDuration defines the total duration
                                     within which events will happen.
                                   type: string
-                                uniform:
-                                  description: DistParamsUniform are parameters for
-                                    the constant distribution.
-                                  properties:
-                                    max:
-                                      format: int64
-                                      type: integer
-                                  required:
-                                  - max
-                                  type: object
-                                zipfian:
-                                  description: DistParamsZipfian are parameters for
-                                    the constant distribution.
-                                  properties:
-                                    max:
-                                      format: int64
-                                      type: integer
-                                  required:
-                                  - max
-                                  type: object
                               required:
                               - distribution
                               - total

--- a/controllers/cluster/controller.go
+++ b/controllers/cluster/controller.go
@@ -26,6 +26,7 @@ import (
 	"github.com/carv-ics-forth/frisbee/controllers/common"
 	"github.com/carv-ics-forth/frisbee/controllers/common/scheduler"
 	"github.com/carv-ics-forth/frisbee/controllers/common/watchers"
+	"github.com/carv-ics-forth/frisbee/pkg/distributions"
 	"github.com/carv-ics-forth/frisbee/pkg/expressions"
 	"github.com/carv-ics-forth/frisbee/pkg/lifecycle"
 	"github.com/go-logr/logr"
@@ -187,6 +188,13 @@ func (r *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 }
 
 func (r *Controller) Initialize(ctx context.Context, cluster *v1alpha1.Cluster) error {
+	/*
+		calculate any top-level distribution. this distribution will be respected during the construction of the jobs.
+	*/
+	if distName := cluster.Spec.DefaultDistributionSpec; distName != nil {
+		cluster.Status.DefaultDistribution = distributions.GetPointDistribution(int64(cluster.Spec.MaxInstances), distName)
+	}
+
 	/*
 		We construct a list of job specifications based on the CR's template.
 		This list is used by the execution step to create the actual job.

--- a/examples/10b.resource-distribution.yml
+++ b/examples/10b.resource-distribution.yml
@@ -56,7 +56,8 @@ spec:
         # Create a variety of clients with different resource distribution
         resources:
           total: { cpu: "2", memory: "1Gi" }
-          distribution: zipfian
+          distribution:
+            name: zipfian
 
     # When all actions are done, delete looping servers to gracefully exit the experiment
     - action: Delete

--- a/examples/6b.timeline-distribution.yml
+++ b/examples/6b.timeline-distribution.yml
@@ -57,7 +57,8 @@ spec:
         schedule:
           timeline:
             total: 3m
-            distribution: zipfian
+            distribution:
+              name: zipfian
 
     # When all actions are done, delete looping servers to gracefully exit the experiment
     - action: Delete


### PR DESCRIPTION
DefaultDistributionSpec pre-calculates a scoped distribution that can be accessed by other entities using  "distribution.name : default". 

This default distribution allows us to describe complex relations across features managed by different entities  (e.g, place the largest dataset on the largest node).