### PR TITLE
add example for crashing nodes on federated training

### DIFF
--- a/charts/federated-learning/fedbed/templates/server.yaml
+++ b/charts/federated-learning/fedbed/templates/server.yaml
@@ -113,7 +113,7 @@ spec:
           - /bin/bash
           - -c
           - |
-            export ROUND=2
+            export ROUND=1
 
             while true; do
               (( $(grep "fit_round received" /fl-logs/server.log | wc -l) > ${ROUND} )) && break || sleep 5;

--- a/controllers/cascade/jobs.go
+++ b/controllers/cascade/jobs.go
@@ -50,12 +50,12 @@ func (r *Controller) runJob(ctx context.Context, cascade *v1alpha1.Cascade, jobI
 
 // buildJobQueue creates a list of job templates that will be scheduled throughout execution.
 func (r *Controller) buildJobQueue(ctx context.Context, cascade *v1alpha1.Cascade) ([]v1alpha1.ChaosSpec, error) {
-	specs, err := chaosutils.GetChaosSpecList(ctx, r.GetClient(), cascade, cascade.Spec.GenerateObjectFromTemplate)
+	chaosSpecs, err := chaosutils.GetChaosSpecList(ctx, r.GetClient(), cascade, cascade.Spec.GenerateObjectFromTemplate)
 	if err != nil {
-		return nil, errors.Wrapf(err, "cannot get specs")
+		return nil, errors.Wrapf(err, "cannot get chaosSpecs")
 	}
 
 	cascadeutils.SetTimeline(cascade)
 
-	return specs, nil
+	return chaosSpecs, nil
 }

--- a/controllers/cascade/lifecycle.go
+++ b/controllers/cascade/lifecycle.go
@@ -65,10 +65,12 @@ func (r *Controller) updateLifecycle(cr *v1alpha1.Cascade) bool {
 		// Event used in conjunction with "Until", instance act as a maximum bound.
 		// If the maximum instances are reached before the Until conditions, we assume that
 		// the experiment never converges, and it fails.
-		if cr.Spec.MaxInstances > 0 && cr.Status.ScheduledJobs > cr.Spec.MaxInstances {
-			msg := fmt.Sprintf(`Cascade [%s] has reached Max instances [%d] before Until conditions are met.
+		maxJobs := cr.Spec.MaxInstances
+
+		if maxJobs > 0 && (cr.Status.ScheduledJobs > maxJobs) {
+			msg := fmt.Sprintf(`Resource [%s] has reached Max instances [%d] before Until conditions are met.
 			Abort the experiment as it too flaky to accept. You can retry without defining instances.`,
-				cr.GetName(), cr.Spec.MaxInstances)
+				cr.GetName(), maxJobs)
 
 			cr.Status.Lifecycle.Phase = v1alpha1.PhaseFailed
 			cr.Status.Lifecycle.Reason = "MaxInstancesReached"

--- a/examples/federated_learning/crash-on-epoch/manifest.yml
+++ b/examples/federated_learning/crash-on-epoch/manifest.yml
@@ -40,17 +40,17 @@ spec:
         callable: wait-for-round
         services: [server]
 
-    # Step 4: Kill one client 2 minutes after the 2nd round, and another client 2 minutes later.
+    # Step 4: After 2 minutes, kill one client, and 1 minutes later, kill another client.
     - action: Cascade
       name: killer
-      depends: { success: [  wait-for-round ] }
+      depends: { success: [ wait-for-round ] }
       cascade:
         templateRef: system.chaos.pod.kill
         inputs:
           - { target: clients-1 }
           - { target: clients-3 }
         schedule:
-          cron: "@every 2m"
+          cron: "@every 1m"
 
 
     # Teardown


### PR DESCRIPTION
Add a testing pattern for a federated learning pipeline that tolerates one crashing node before the training stops.